### PR TITLE
updated readme options for multi-task, when on multitask options should ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,12 @@ Since the `grunt-dox` task is a multi task, you can create several tasks for dox
 ```js
 dox: {
   libdocs :{
-    files: {
-      src: ['js/lib/'],
-      dest: 'docs'
-    }
+    src: ['js/lib/'],
+    dest: 'docs'
   },
   sourcedocs :{
-    files: {
-      src: ['js/src/'],
-      dest: 'docs'
-    }
+    src: ['js/src/'],
+    dest: 'docs'
   }
 },
 ```


### PR DESCRIPTION
Config options on the readme needs to be updated, since when wraping config with 'files' cause a multi-task error.

```
dox: {
  libdocs :{
    files: {
      src: ['js/lib/'],
      dest: 'docs'
    }
  },
  sourcedocs :{
    files: {
      src: ['js/src/'],
      dest: 'docs'
    }
  }
},
```

it should instead look like this:

```
dox: {
  libdocs :{
    src: ['js/lib/'],
    dest: 'docs'
  },
  sourcedocs :{
    src: ['js/src/'],
    dest: 'docs'
  }
},
```
