### PR TITLE
Adds template path as option

### DIFF
--- a/tasks/dox.js
+++ b/tasks/dox.js
@@ -40,6 +40,11 @@ module.exports = function(grunt) {
       _args.push('"' + _opts.title + '"');
     }
 
+    if (_opts.template) {
+      _args.push('--template');
+      _args.push('"' + _opts.template + '"');
+    }
+
     // Pass through ignore params if set
     if (this.data.ignore) {
       _args.push('--ignore');


### PR DESCRIPTION
Relies on @dawicorti's pull request for `dox-foundation` itself that gets `--template` working: https://github.com/punkave/dox-foundation/pull/47
